### PR TITLE
disable immintrin.h

### DIFF
--- a/src/sdl2.h
+++ b/src/sdl2.h
@@ -1,6 +1,7 @@
 #ifndef SDL2_H__
 #define SDL2_H__
 
+#define SDL_DISABLE_IMMINTRIN_H 1
 #include <SDL.h>
 #include <idris_rts.h>
 


### PR DESCRIPTION
On OpenBSD this file can not be found.

I'm not sure about the consequences of disabling it but I wasn't able to compile it otherwise.